### PR TITLE
feat: 구글 계정정보 연동 구현 

### DIFF
--- a/src/main/java/staysplit/hotel_reservation/common/entity/Response.java
+++ b/src/main/java/staysplit/hotel_reservation/common/entity/Response.java
@@ -8,12 +8,17 @@ import lombok.Getter;
 public class Response<T> {
     private String resultCode;
     private T result;
+    private T data;
 
     public static <T> Response<T> success(T result) {
-        return new Response<>("SUCCESS", result);
+        return new Response<>("SUCCESS", result,null);
     }
 
     public static <T> Response<T> error(T result) {
-        return new Response<>("ERROR", result);
+        return new Response<>("ERROR", result,null);
     }
+    public static <T> Response<T> warn(T result, T data) {
+        return new Response<>("WARN", result,data);
+    }
+
 }

--- a/src/main/java/staysplit/hotel_reservation/common/oauth/dto/GoogleProfileDto.java
+++ b/src/main/java/staysplit/hotel_reservation/common/oauth/dto/GoogleProfileDto.java
@@ -12,5 +12,7 @@ import lombok.NoArgsConstructor;
 public class GoogleProfileDto {
     private String sub;
     private String email;
+    private String given_name;
+    private String family_name;
     //private String picture;
 }

--- a/src/main/java/staysplit/hotel_reservation/common/oauth/service/GoogleService.java
+++ b/src/main/java/staysplit/hotel_reservation/common/oauth/service/GoogleService.java
@@ -1,6 +1,5 @@
 package staysplit.hotel_reservation.common.oauth.service;
 
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -18,8 +17,6 @@ import staysplit.hotel_reservation.common.exception.ErrorCode;
 import staysplit.hotel_reservation.common.oauth.dto.AccessTokenDto;
 import staysplit.hotel_reservation.common.oauth.dto.GoogleProfileDto;
 
-import java.util.Map;
-
 @Slf4j
 @Service
 public class GoogleService {
@@ -30,6 +27,8 @@ public class GoogleService {
     private String clientSecret;
     @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
     private String redirectUri;
+    @Value("${spring.security.oauth2.client.registration.google.scope}")
+    private String scope;
 
     public AccessTokenDto getAccessToken(String code) {
         try {
@@ -42,6 +41,7 @@ public class GoogleService {
             params.add("client_id", clientId);
             params.add("client_secret", clientSecret);
             params.add("redirect_uri", redirectUri);
+            params.add("scope", scope);
             params.add("grant_type", "authorization_code");
 
 

--- a/src/main/java/staysplit/hotel_reservation/common/oauth/service/OAuthService.java
+++ b/src/main/java/staysplit/hotel_reservation/common/oauth/service/OAuthService.java
@@ -62,7 +62,7 @@ public class OAuthService {
 
         UserEntity user = userRepository.findBySocialId(profile.getSub())
                 .orElseThrow(() -> new AppException(ErrorCode.ADDITIONAL_INFO_REQUIRED,
-                        "socialId: " + profile.getSub() + ", email: " + profile.getEmail()));
+                        "socialId:" + profile.getSub() + "email:" + profile.getEmail()+", name:"+profile.getFamily_name()+profile.getGiven_name()));
 
         return jwtTokenProvider.createToken(user.getEmail(), user.getRole().toString());
     }

--- a/src/main/java/staysplit/hotel_reservation/common/security/jwt/JwtTokenFilter.java
+++ b/src/main/java/staysplit/hotel_reservation/common/security/jwt/JwtTokenFilter.java
@@ -29,32 +29,10 @@ public class JwtTokenFilter extends OncePerRequestFilter {
 
     private final CustomUserDetailsService userDetailsService;
 
-    //FIXME: prefix 기반으로 필터링이므로, 추후 변경
-    private static final List<String> WHITELIST_PREFIXES = List.of(
-            "/api/customers/google",
-            "/api/customers/oauth/signup",
-            "/api/customers/sign-up",
-            "/api/providers/sign-up",
-            "/api/users/login",
-            "/swagger-ui/",
-            "/v3/api-docs"
-    );
-
-    private boolean isWhitelisted(String path) {
-        return WHITELIST_PREFIXES.stream().anyMatch(path::startsWith);
-    }
-
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String path = request.getRequestURI();
         log.info(">>> Incoming request path: {}", path);
-
-        // JWT 검사 예외 경로 (콜백 URL 등)
-        if (isWhitelisted(path)) {
-            log.info(">>> Whitelisted URL detected, skipping JWT filter: {}", path);
-            filterChain.doFilter(request, response);
-            return;
-        }
 
         String jwtToken = null;
         Cookie[] cookies = request.getCookies();
@@ -65,12 +43,6 @@ public class JwtTokenFilter extends OncePerRequestFilter {
                     jwtToken = cookie.getValue();
                 }
             }
-        }
-
-        if (jwtToken == null) {
-            log.warn("JWT 토큰이 없습니다. 인증 실패");
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized: JWT token is missing");
-            return;
         }
 
         try {

--- a/src/main/java/staysplit/hotel_reservation/customer/controller/CustomerController.java
+++ b/src/main/java/staysplit/hotel_reservation/customer/controller/CustomerController.java
@@ -95,7 +95,7 @@ public class CustomerController {
         } catch (AppException e) {
             // 신규 사용자라면 추가 정보 입력 필요
             if (e.getErrorCode() == ErrorCode.ADDITIONAL_INFO_REQUIRED) {
-                return Response.error(ErrorCode.ADDITIONAL_INFO_REQUIRED);
+                return Response.warn(ErrorCode.ADDITIONAL_INFO_REQUIRED, e.getMessage());
             }
             throw e; //다른 에러는 그대로 전파
         }
@@ -107,7 +107,7 @@ public class CustomerController {
         response.sendRedirect(redirectUrl);
     }
 
-//    // Oauth 추가 정보 입력 후 회원가입
+    //  Oauth 추가 정보 입력 후 회원가입
     @PostMapping("/oauth/signup")
     public Response<CustomerDetailsResponse> oauthSignup(@RequestBody OauthSignupRequest request) {
         CustomerDetailsResponse response = oAuthService.oauthSignup(request);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
-            scope: openid, email, profile
+            scope: openid email profile
             redirect-uri: "https://localhost:8443/api/customers/google/callback"
             callback-uri: "https://localhost:5173/oauth/google?code="
             authorization-grant-type: authorization_code


### PR DESCRIPTION
1. jwt 토큰 예외처리 제거 
  - 단, 요청로그는 남겨둠

2. 구글 계정정보 연동 구현 
  - 프론트에서 사용할 계정정보 리턴 처리
  - scope 추가 및 오류나는 scope수정 / 구글에서 제공하지않는 api 응답,dto 수정