### PR TITLE
Feat/main/login

### DIFF
--- a/src/main/java/staysplit/hotel_reservation/common/entity/Response.java
+++ b/src/main/java/staysplit/hotel_reservation/common/entity/Response.java
@@ -8,17 +8,13 @@ import lombok.Getter;
 public class Response<T> {
     private String resultCode;
     private T result;
-    private T data;
 
     public static <T> Response<T> success(T result) {
-        return new Response<>("SUCCESS", result,null);
+        return new Response<>("SUCCESS", result);
     }
 
     public static <T> Response<T> error(T result) {
-        return new Response<>("ERROR", result,null);
-    }
-    public static <T> Response<T> warn(T result, T data) {
-        return new Response<>("WARN", result,data);
+        return new Response<>("ERROR", result);
     }
 
 }

--- a/src/main/java/staysplit/hotel_reservation/common/entity/ResultWrapper.java
+++ b/src/main/java/staysplit/hotel_reservation/common/entity/ResultWrapper.java
@@ -1,0 +1,15 @@
+package staysplit.hotel_reservation.common.entity;
+
+import lombok.Getter;
+
+@Getter
+public class ResultWrapper<T> {
+    private String code;
+    private T data;
+
+    public ResultWrapper(String code, T data) {
+        this.code = code;
+        this.data = data;
+    }
+
+}

--- a/src/main/java/staysplit/hotel_reservation/common/exception/ErrorCode.java
+++ b/src/main/java/staysplit/hotel_reservation/common/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     PROVIDER_ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 존재하는 공급자입니다"),
     USER_NOT_LOGGED_IN(HttpStatus.UNAUTHORIZED, "로그인 상태가 아닙니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다."),
+    INVALID_ACCOUNT_TYPE(HttpStatus.NOT_FOUND, "지원하지 않는 소셜 타입입니다."),
 
     // Room
     ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 방입니다"),

--- a/src/main/java/staysplit/hotel_reservation/common/oauth/controller/AuthController.java
+++ b/src/main/java/staysplit/hotel_reservation/common/oauth/controller/AuthController.java
@@ -9,6 +9,7 @@ import staysplit.hotel_reservation.common.oauth.dto.OauthSignupRequest;
 import staysplit.hotel_reservation.common.oauth.dto.RedirectDto;
 import staysplit.hotel_reservation.common.oauth.service.OAuthService;
 import staysplit.hotel_reservation.customer.domain.dto.response.CustomerDetailsResponse;
+import staysplit.hotel_reservation.user.domain.dto.response.UserLoginResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,8 +22,8 @@ public class AuthController {
     public Response<?> googleLogin(@RequestBody RedirectDto redirectDto) {
         try {
             // 기존 사용자라면 jwt 반환
-            String jwt = oAuthService.getGoogleUserInfo(redirectDto);
-            return Response.success(jwt);
+            UserLoginResponse response = oAuthService.getGoogleUserInfo(redirectDto);
+            return Response.success(response.jwt());
         } catch (AppException e) {
             // 신규 사용자라면 추가 정보 입력 필요
             if (e.getErrorCode() == ErrorCode.ADDITIONAL_INFO_REQUIRED) {

--- a/src/main/java/staysplit/hotel_reservation/common/oauth/dto/OauthSignupRequest.java
+++ b/src/main/java/staysplit/hotel_reservation/common/oauth/dto/OauthSignupRequest.java
@@ -15,5 +15,6 @@ public class OauthSignupRequest {
     private String name; // From Google OAUTH, 카카오는 사용자 입력
     private String nickname; // 사용자 입력값
     private LocalDate birthdate; // 사용자 입력값
+    private String accountType;
 
 }

--- a/src/main/java/staysplit/hotel_reservation/customer/domain/dto/SocialType.java
+++ b/src/main/java/staysplit/hotel_reservation/customer/domain/dto/SocialType.java
@@ -1,5 +1,0 @@
-package staysplit.hotel_reservation.customer.domain.dto;
-
-public enum SocialType {
-    GOOGLE, KAKAO
-}

--- a/src/main/java/staysplit/hotel_reservation/customer/domain/entity/CustomerEntity.java
+++ b/src/main/java/staysplit/hotel_reservation/customer/domain/entity/CustomerEntity.java
@@ -2,8 +2,8 @@ package staysplit.hotel_reservation.customer.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import staysplit.hotel_reservation.customer.domain.dto.SocialType;
 import staysplit.hotel_reservation.user.domain.entity.UserEntity;
+import staysplit.hotel_reservation.user.domain.enums.AccountType;
 
 import java.time.LocalDate;
 
@@ -35,7 +35,7 @@ public class CustomerEntity {
     private String nickname;
 
     @Enumerated(EnumType.STRING)
-    private SocialType socialType;
+    private AccountType account_type;
 
     private String socialId;
 }

--- a/src/main/java/staysplit/hotel_reservation/customer/service/CustomerService.java
+++ b/src/main/java/staysplit/hotel_reservation/customer/service/CustomerService.java
@@ -13,7 +13,7 @@ import staysplit.hotel_reservation.customer.domain.entity.CustomerEntity;
 import staysplit.hotel_reservation.customer.domain.dto.response.CustomerDetailsResponse;
 import staysplit.hotel_reservation.customer.repository.CustomerRepository;
 import staysplit.hotel_reservation.user.domain.entity.UserEntity;
-import staysplit.hotel_reservation.user.domain.enums.LoginSource;
+import staysplit.hotel_reservation.user.domain.enums.AccountType;
 import staysplit.hotel_reservation.user.domain.enums.Role;
 import staysplit.hotel_reservation.user.repository.UserRepository;
 
@@ -40,7 +40,7 @@ public class CustomerService {
                 .email(request.email())
                 .password(passwordEncoder.encode(request.password()))
                 .role(Role.CUSTOMER)
-                .loginSource(LoginSource.LOCAL)
+                .account_type(AccountType.LOCAL)
                 .build();
 
         userRepository.save(user);

--- a/src/main/java/staysplit/hotel_reservation/provider/service/ProviderService.java
+++ b/src/main/java/staysplit/hotel_reservation/provider/service/ProviderService.java
@@ -6,14 +6,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import staysplit.hotel_reservation.common.exception.AppException;
 import staysplit.hotel_reservation.common.exception.ErrorCode;
-import staysplit.hotel_reservation.hotel.repository.HotelRepository;
 import staysplit.hotel_reservation.provider.domain.dto.reqeust.ProviderSignupRequest;
 import staysplit.hotel_reservation.provider.domain.dto.response.ProviderDetailResponse;
 import staysplit.hotel_reservation.provider.domain.dto.response.ProviderSignupResponse;
 import staysplit.hotel_reservation.provider.domain.entity.ProviderEntity;
 import staysplit.hotel_reservation.provider.repository.ProviderRepository;
 import staysplit.hotel_reservation.user.domain.entity.UserEntity;
-import staysplit.hotel_reservation.user.domain.enums.LoginSource;
+import staysplit.hotel_reservation.user.domain.enums.AccountType;
 import staysplit.hotel_reservation.user.domain.enums.Role;
 import staysplit.hotel_reservation.user.repository.UserRepository;
 
@@ -35,7 +34,7 @@ public class ProviderService {
                 .email(request.email())
                 .password(passwordEncoder.encode(request.password()))
                 .role(Role.PROVIDER)
-                .loginSource(LoginSource.LOCAL)
+                .account_type(AccountType.LOCAL)
                 .build();
 
         userRepository.save(user);

--- a/src/main/java/staysplit/hotel_reservation/user/controller/UserController.java
+++ b/src/main/java/staysplit/hotel_reservation/user/controller/UserController.java
@@ -5,6 +5,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -36,11 +38,14 @@ public class UserController {
     public Response<String> login(@Valid @RequestBody LoginRequest loginRequest, HttpServletResponse httpServletResponse) {
         UserLoginResponse response = userService.login(loginRequest);
 
-        Cookie cookie = new Cookie("token", response.jwt());
-        cookie.setMaxAge(jwtExpirationInSeconds);
-        cookie.setHttpOnly(true);
-        cookie.setPath("/");
-        httpServletResponse.addCookie(cookie);
+        ResponseCookie cookie = ResponseCookie.from("token", response.jwt())
+                .httpOnly(true)
+                .secure(false)
+                .path("/")
+                .sameSite("Lax")
+                .maxAge(jwtExpirationInSeconds)
+                .build();
+        httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
         return Response.success("ROLE_" + response.role());
     }

--- a/src/main/java/staysplit/hotel_reservation/user/domain/entity/UserEntity.java
+++ b/src/main/java/staysplit/hotel_reservation/user/domain/entity/UserEntity.java
@@ -3,7 +3,7 @@ package staysplit.hotel_reservation.user.domain.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import staysplit.hotel_reservation.common.entity.BaseEntity;
-import staysplit.hotel_reservation.user.domain.enums.LoginSource;
+import staysplit.hotel_reservation.user.domain.enums.AccountType;
 import staysplit.hotel_reservation.user.domain.enums.Role;
 
 @Entity
@@ -26,8 +26,8 @@ public class UserEntity extends BaseEntity {
     private Role role;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "login_source", nullable = false)
-    private LoginSource loginSource;
+    @Column(name = "account_type", nullable = false)
+    private AccountType account_type;
 
     @Column(name = "social_id", unique = true)
     private String socialId;

--- a/src/main/java/staysplit/hotel_reservation/user/domain/enums/AccountType.java
+++ b/src/main/java/staysplit/hotel_reservation/user/domain/enums/AccountType.java
@@ -1,6 +1,6 @@
 package staysplit.hotel_reservation.user.domain.enums;
 
 
-public enum LoginSource {
+public enum AccountType {
     LOCAL, GOOGLE, KAKAO
 }


### PR DESCRIPTION
1.oauth 가입 예외처리 로직 추가
  -지원하지 않는 oauth 예외처리 및 에러타입 추가
  -customer/user테이블의 분리된 컬럼명 통일 (accountType)
  -회원가입시 socialId insert되도록 수정
2.warn응답 제거
3.구글로그인시 계정정보 전달로직 추가
  -로그인에 대한 Role응답 추가 (ResultWrapper)
  -user는 email로 find하도록 통일(email/socialId 중복 관련 회피) 
4.쿠키생성 방식 통일
  -서블릿방식이 아닌 스프링방식으로 사용

