### PR TITLE
feat: oAuth 계정정보 전달 구현/검증 방식 변경 

### DIFF
--- a/src/main/java/staysplit/hotel_reservation/common/oauth/service/OAuthService.java
+++ b/src/main/java/staysplit/hotel_reservation/common/oauth/service/OAuthService.java
@@ -18,6 +18,7 @@ import staysplit.hotel_reservation.user.domain.enums.AccountType;
 import staysplit.hotel_reservation.user.domain.enums.Role;
 import staysplit.hotel_reservation.user.repository.UserRepository;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -75,7 +76,7 @@ public class OAuthService {
         UserEntity user = userRepository.findByEmail(profile.getEmail())
                 .orElseThrow(() -> new AppException(ErrorCode.ADDITIONAL_INFO_REQUIRED,
                         "socialId:" + profile.getSub() + "email:" + profile.getEmail()+", name:"+profile.getFamily_name()+profile.getGiven_name()));
-
+log.error("!!!!! {}",user);
         String jwt = jwtTokenProvider.createToken(user.getEmail(), user.getRole().toString());
         String role = user.getRole().toString();
 

--- a/src/main/java/staysplit/hotel_reservation/common/oauth/service/OAuthService.java
+++ b/src/main/java/staysplit/hotel_reservation/common/oauth/service/OAuthService.java
@@ -76,7 +76,7 @@ public class OAuthService {
         UserEntity user = userRepository.findByEmail(profile.getEmail())
                 .orElseThrow(() -> new AppException(ErrorCode.ADDITIONAL_INFO_REQUIRED,
                         "socialId:" + profile.getSub() + "email:" + profile.getEmail()+", name:"+profile.getFamily_name()+profile.getGiven_name()));
-log.error("!!!!! {}",user);
+
         String jwt = jwtTokenProvider.createToken(user.getEmail(), user.getRole().toString());
         String role = user.getRole().toString();
 

--- a/src/main/java/staysplit/hotel_reservation/customer/controller/CustomerController.java
+++ b/src/main/java/staysplit/hotel_reservation/customer/controller/CustomerController.java
@@ -95,7 +95,6 @@ public class CustomerController {
                     .build();
             response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
-            log.error("!!!!!@@@ {}",loginResponse);
             return Response.success(
                     new ResultWrapper<>("SUCCESS", "ROLE_" + loginResponse.role())
             );

--- a/src/main/java/staysplit/hotel_reservation/customer/controller/CustomerController.java
+++ b/src/main/java/staysplit/hotel_reservation/customer/controller/CustomerController.java
@@ -3,6 +3,7 @@ package staysplit.hotel_reservation.customer.controller;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.security.core.Authentication;
@@ -22,6 +23,7 @@ import staysplit.hotel_reservation.user.domain.dto.response.UserLoginResponse;
 
 import java.io.IOException;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/customers")
 @RequiredArgsConstructor
@@ -92,7 +94,8 @@ public class CustomerController {
                     .maxAge(jwtExpirationInSeconds)
                     .build();
             response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
-            
+
+            log.error("!!!!!@@@ {}",loginResponse);
             return Response.success(
                     new ResultWrapper<>("SUCCESS", "ROLE_" + loginResponse.role())
             );

--- a/src/main/java/staysplit/hotel_reservation/user/controller/UserController.java
+++ b/src/main/java/staysplit/hotel_reservation/user/controller/UserController.java
@@ -76,12 +76,13 @@ public class UserController {
             throw new AppException(ErrorCode.USER_NOT_LOGGED_IN, ErrorCode.USER_NOT_FOUND.getMessage());
         }
         String email = userDetails.getUsername();
+        String nickName = userService.getNickName(email);
         String role = userDetails.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .findFirst()
                 .orElse("UNKNOWN");
 
-        UserLoginStatusResponse response = new UserLoginStatusResponse(email, role, true);
+        UserLoginStatusResponse response = new UserLoginStatusResponse(email, nickName, role, true);
         return Response.success(response);
     }
 }

--- a/src/main/java/staysplit/hotel_reservation/user/domain/dto/response/UserLoginStatusResponse.java
+++ b/src/main/java/staysplit/hotel_reservation/user/domain/dto/response/UserLoginStatusResponse.java
@@ -2,6 +2,7 @@ package staysplit.hotel_reservation.user.domain.dto.response;
 
 public record UserLoginStatusResponse(
         String email,
+        String nickName,
         String role,
         Boolean loggedIn
 ) {

--- a/src/main/java/staysplit/hotel_reservation/user/service/UserService.java
+++ b/src/main/java/staysplit/hotel_reservation/user/service/UserService.java
@@ -7,6 +7,8 @@ import org.springframework.transaction.annotation.Transactional;
 import staysplit.hotel_reservation.common.exception.AppException;
 import staysplit.hotel_reservation.common.exception.ErrorCode;
 import staysplit.hotel_reservation.common.security.jwt.JwtTokenProvider;
+import staysplit.hotel_reservation.customer.domain.entity.CustomerEntity;
+import staysplit.hotel_reservation.customer.repository.CustomerRepository;
 import staysplit.hotel_reservation.user.domain.dto.request.PasswordUpdateRequest;
 import staysplit.hotel_reservation.user.domain.dto.response.UserLoginResponse;
 import staysplit.hotel_reservation.user.domain.entity.UserEntity;
@@ -18,6 +20,7 @@ import staysplit.hotel_reservation.user.repository.UserRepository;
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final CustomerRepository customerRepository;
     private final BCryptPasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -40,6 +43,13 @@ public class UserService {
         UserEntity user = validateUser(email);
         user.changePassword(passwordEncoder.encode(request.password()));
         return "비밀번호가 변경되었습니다.";
+    }
+
+    public String getNickName(String email){
+        CustomerEntity customer = customerRepository.findByUserEmail(email)
+                .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND,
+                        ErrorCode.USER_NOT_FOUND.getMessage()));
+        return customer.getNickname();
     }
 
     private UserEntity validateUser(String email) {


### PR DESCRIPTION
1.oAuth 계정정보 전달 구현 및 검증 방식 변경

    -oauth 가입 예외처리 로직 추가
      -지원하지 않는 oauth 예외처리 및 에러타입 추가
      -customer/user테이블의 분리된 컬럼명 통일 (accountType)
      -회원가입시 socialId insert되도록 수정
    -warn응답 제거
    -구글로그인시 계정정보 전달로직 추가
      -로그인에 대한 Role응답 추가 (ResultWrapper)
      -user는 email로 find하도록 통일(email/socialId 중복 관련 회피)
    -쿠키생성 방식 통일
      -서블릿방식이 아닌 스프링방식으로 사용
      

2. 로그인시 사용자 정보 체크시 닉네임 리턴 추가
    -email,nickName,role을 프론트에서 사용하도록 수정
    